### PR TITLE
Initial faction storage implementation (+ enabled kotlin support)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,10 +28,11 @@ dependencies {
     
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
     modImplementation "me.lucko:fabric-permissions-api:${project.lucko_permissions_version}"
+    modImplementation "net.fabricmc:fabric-language-kotlin:${project.fabric_kotlin_version}"
+
     include "me.lucko:fabric-permissions-api:${project.lucko_permissions_version}"
     compileOnly "us.dynmap:DynmapCoreAPI:${project.dynmap_api_version}"
     implementation(include("com.h2database:h2:${project.h2_version}"))
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,17 +2,17 @@ org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
 minecraft_version=1.19
-yarn_mappings=1.19+build.1
-loader_version=0.14.6
+yarn_mappings=1.19+build.4
+loader_version=0.14.8
 
 # Mod Properties
-mod_version = 2.0.6
+mod_version = 2.1.0
 maven_group = io.icker
 archives_base_name = factions
 
 # Dependencies
 h2_version=1.4.200
-fabric_version=0.55.2+1.19
+fabric_version=0.56.3+1.19
 lucko_permissions_version=0.1-SNAPSHOT
 dynmap_api_version=3.4-beta-3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,7 @@ h2_version=1.4.200
 fabric_version=0.55.2+1.19
 lucko_permissions_version=0.1-SNAPSHOT
 dynmap_api_version=3.4-beta-3
+
+# Kotlin
+kotlin_version=1.7.0
+fabric_kotlin_version=1.8.0+kotlin.1.7.0

--- a/src/main/java/io/icker/factions/FactionsMod.java
+++ b/src/main/java/io/icker/factions/FactionsMod.java
@@ -81,6 +81,7 @@ public class FactionsMod implements ModInitializer {
             new ModifyCommand(),
             new RadarCommand(),
             new RankCommand(),
+            new StorageCommand(),
         };
 
         for (Command command : commands) {

--- a/src/main/java/io/icker/factions/core/FactionsManager.java
+++ b/src/main/java/io/icker/factions/core/FactionsManager.java
@@ -15,6 +15,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 public class FactionsManager {
     public static PlayerManager playerManager;
@@ -34,7 +35,10 @@ public class FactionsManager {
     }
 
     private static void factionModified(Faction faction) {
-        List<ServerPlayerEntity> players = faction.getUsers().stream().map(user -> playerManager.getPlayer(user.getID())).filter(player -> player != null).toList();
+        List<ServerPlayerEntity> players = faction.getUsers().stream()
+                .map(user -> playerManager.getPlayer(user.getID()))
+                .filter(Objects::nonNull)
+                .toList();
         updatePlayerList(players);
     }
 

--- a/src/main/java/io/icker/factions/core/ServerManager.java
+++ b/src/main/java/io/icker/factions/core/ServerManager.java
@@ -19,6 +19,7 @@ public class ServerManager {
         Claim.save();
         Faction.save();
         User.save();
+        FactionStorage.Companion.saveFactionStorageObjects();
     }
 
     private static void playerJoin(ServerPlayNetworkHandler handler, PacketSender sender, MinecraftServer server) {

--- a/src/main/java/io/icker/factions/mixin/EnderChestMixin.java
+++ b/src/main/java/io/icker/factions/mixin/EnderChestMixin.java
@@ -18,7 +18,7 @@ public class EnderChestMixin {
             value = "INVOKE",
             target = "Lnet/minecraft/world/World;getBlockEntity(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/block/entity/BlockEntity;"
     ), method = "onUse", name = "enderChestInventory")
-    public EnderChestInventory openFactionChest2(EnderChestInventory value, BlockState state, World world, BlockPos pos, PlayerEntity player) {
+    public EnderChestInventory openFactionChest(EnderChestInventory value, BlockState state, World world, BlockPos pos, PlayerEntity player) {
         if (!FactionStorage.Companion.isFactionEnderChest(pos))
             return value;
 

--- a/src/main/java/io/icker/factions/mixin/EnderChestMixin.java
+++ b/src/main/java/io/icker/factions/mixin/EnderChestMixin.java
@@ -5,38 +5,25 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.EnderChestBlock;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.EnderChestInventory;
-import net.minecraft.util.ActionResult;
-import net.minecraft.util.Hand;
-import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(EnderChestBlock.class)
 public class EnderChestMixin {
 
-    @Inject(at = @At(
-            value = "INVOKE_ASSIGN",
-            target = "Lnet/minecraft/entity/player/PlayerEntity;getEnderChestInventory()Lnet/minecraft/inventory/EnderChestInventory;"
-    ), method = "onUse", locals = LocalCapture.CAPTURE_FAILSOFT)
-    public void openFactionChest(
-            BlockState state, World world,
-            BlockPos pos, PlayerEntity player,
-            Hand hand, BlockHitResult hit,
-            CallbackInfoReturnable<ActionResult> cir,
-            EnderChestInventory enderChestInventory
-    ) {
+    @ModifyVariable(at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/World;getBlockEntity(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/block/entity/BlockEntity;"
+    ), method = "onUse", name = "enderChestInventory")
+    public EnderChestInventory openFactionChest2(EnderChestInventory value, BlockState state, World world, BlockPos pos, PlayerEntity player) {
         if (!FactionStorage.Companion.isFactionEnderChest(pos))
-            return;
+            return value;
 
         EnderChestInventory factionInventory = FactionStorage.Companion.tryOpenFactionEnderChest(player);
-        if (factionInventory != null)
-            enderChestInventory = factionInventory;
-
+        return factionInventory != null ? factionInventory : value;
     }
 
 }

--- a/src/main/java/io/icker/factions/mixin/EnderChestMixin.java
+++ b/src/main/java/io/icker/factions/mixin/EnderChestMixin.java
@@ -1,0 +1,42 @@
+package io.icker.factions.mixin;
+
+import io.icker.factions.core.FactionStorage;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.EnderChestBlock;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.EnderChestInventory;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(EnderChestBlock.class)
+public class EnderChestMixin {
+
+    @Inject(at = @At(
+            value = "INVOKE_ASSIGN",
+            target = "Lnet/minecraft/entity/player/PlayerEntity;getEnderChestInventory()Lnet/minecraft/inventory/EnderChestInventory;"
+    ), method = "onUse", locals = LocalCapture.CAPTURE_FAILSOFT)
+    public void openFactionChest(
+            BlockState state, World world,
+            BlockPos pos, PlayerEntity player,
+            Hand hand, BlockHitResult hit,
+            CallbackInfoReturnable<ActionResult> cir,
+            EnderChestInventory enderChestInventory
+    ) {
+        if (!FactionStorage.Companion.isFactionEnderChest(pos))
+            return;
+
+        EnderChestInventory factionInventory = FactionStorage.Companion.tryOpenFactionEnderChest(player);
+        if (factionInventory != null)
+            enderChestInventory = factionInventory;
+
+    }
+
+}

--- a/src/main/kotlin/io/icker/factions/command/StorageCommand.kt
+++ b/src/main/kotlin/io/icker/factions/command/StorageCommand.kt
@@ -23,7 +23,12 @@ class StorageCommand : Command {
             return 0
         }
 
-        FactionStorage.toggleFactionEnderChest(pos)
+        if (FactionStorage.toggleFactionEnderChest(pos)) {
+            Message("Ender chest is now used as faction storage.").send(player, false)
+        } else {
+            Message("Ender chest is no longer as faction storage.").send(player, false)
+        }
+
 
         return 1
     }

--- a/src/main/kotlin/io/icker/factions/command/StorageCommand.kt
+++ b/src/main/kotlin/io/icker/factions/command/StorageCommand.kt
@@ -1,0 +1,40 @@
+package io.icker.factions.command
+
+import com.mojang.brigadier.context.CommandContext
+import com.mojang.brigadier.tree.LiteralCommandNode
+import io.icker.factions.core.FactionStorage
+import io.icker.factions.util.Command
+import io.icker.factions.util.Message
+import net.minecraft.block.Blocks
+import net.minecraft.command.argument.BlockPosArgumentType
+import net.minecraft.server.command.CommandManager
+import net.minecraft.server.command.ServerCommandSource
+
+class StorageCommand : Command {
+    private fun toggleChestMode(context: CommandContext<ServerCommandSource>): Int {
+        val source = context.source
+        val player = source.player
+        val world = source.world
+
+        val pos = BlockPosArgumentType.getBlockPos(context, "pos")
+        val block = world.getBlockState(pos)
+        if (!block.isOf(Blocks.ENDER_CHEST)) {
+            Message("Target block must be an ender chest.").send(player, false)
+            return 0
+        }
+
+        FactionStorage.toggleFactionEnderChest(pos)
+
+        return 1
+    }
+
+    override fun getNode(): LiteralCommandNode<ServerCommandSource> {
+        return CommandManager
+            .literal("toggleChestMode")
+            .then(
+                CommandManager.argument("pos", BlockPosArgumentType.blockPos())
+                    .executes(this::toggleChestMode)
+            )
+            .build()
+    }
+}

--- a/src/main/kotlin/io/icker/factions/core/FactionStorage.kt
+++ b/src/main/kotlin/io/icker/factions/core/FactionStorage.kt
@@ -1,0 +1,105 @@
+package io.icker.factions.core
+
+import io.icker.factions.api.persistents.User
+import io.icker.factions.data.ToNbt
+import io.icker.factions.data.DataStore
+import io.icker.factions.data.FromNbt
+import io.icker.factions.util.Message
+import net.minecraft.entity.player.PlayerEntity
+import net.minecraft.inventory.EnderChestInventory
+import net.minecraft.nbt.NbtElement
+import net.minecraft.nbt.NbtIntArray
+import net.minecraft.nbt.NbtList
+import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.Vec3i
+import java.util.UUID
+
+class FactionStorage(private var isInUse: Boolean = false) : EnderChestInventory(), ToNbt<FactionStorage> {
+
+    companion object : FromNbt<FactionStorage> {
+        private const val chestMapFile = "chestMap.dat"
+
+        private val factionChestMap: HashSet<Vec3i> = DataStore.loadObject(chestMapFile, {factionChestMapFromNbt(it)}) { HashSet() }
+        private val factionInventories: HashMap<UUID, FactionStorage> by lazy { HashMap() }
+
+        fun saveFactionStorageObjects() {
+            DataStore.saveObject(chestMapFile, factionChestMap) { factionChestMapToNbt(it) }
+            factionInventories.forEach { (uuid, factionStorage) ->
+                DataStore.saveObject("inventories/${uuid}.dat", factionStorage)
+            }
+        }
+
+        fun isFactionEnderChest(pos: BlockPos): Boolean = factionChestMap.contains(pos)
+
+        fun toggleFactionEnderChest(pos: BlockPos) {
+            if (factionChestMap.contains(pos)) {
+                factionChestMap.remove(pos)
+            } else {
+                factionChestMap.add(pos)
+            }
+        }
+
+        fun tryOpenFactionEnderChest(player: PlayerEntity): EnderChestInventory? {
+            val user = User.get(player.uuid)
+            val faction = user.faction
+
+            if (faction == null) {
+                Message("You cannot use faction storage when you are not in a faction.").send(player, false)
+                return null
+            }
+
+            val inventory = if (faction.id in factionInventories) factionInventories[faction.id]!!
+                else DataStore.loadObject("inventories/${faction.id}.dat", FactionStorage) { FactionStorage() }
+
+            if (inventory.isInUse) {
+                Message("Faction inventory is currently in use. Please try again later.")
+                    .send(player, false)
+                return null
+            }
+
+            inventory.isInUse = true
+
+            return inventory
+        }
+
+        private fun factionChestMapFromNbt(element: NbtElement): HashSet<Vec3i> {
+            if (element is NbtList)
+                return HashSet(element.map {
+                    val e = it as NbtIntArray
+                    Vec3i(e[0].intValue(), e[1].intValue(), e[2].intValue())
+                })
+            return HashSet()
+        }
+
+        private fun factionChestMapToNbt(chestMap: HashSet<Vec3i>): NbtList {
+            val list = NbtList()
+            chestMap.forEach {
+                NbtIntArray(intArrayOf(it.x, it.y, it.z))
+                    .let { pos -> list.add(pos)}
+            }
+
+            return list
+        }
+
+        override fun fromNbt(nbt: NbtElement): FactionStorage {
+            val inventory = FactionStorage()
+            if (nbt is NbtList)
+                inventory.readNbtList(nbt)
+
+            return inventory
+        }
+
+    }
+
+    override fun onClose(player: PlayerEntity?) {
+        isInUse = false
+        super.onClose(player)
+    }
+
+
+    override fun toNbt(): NbtElement {
+        return toNbtList()
+    }
+
+
+}

--- a/src/main/kotlin/io/icker/factions/core/FactionStorage.kt
+++ b/src/main/kotlin/io/icker/factions/core/FactionStorage.kt
@@ -31,11 +31,13 @@ class FactionStorage(private var isInUse: Boolean = false) : EnderChestInventory
 
         fun isFactionEnderChest(pos: BlockPos): Boolean = factionChestMap.contains(pos)
 
-        fun toggleFactionEnderChest(pos: BlockPos) {
-            if (factionChestMap.contains(pos)) {
+        fun toggleFactionEnderChest(pos: BlockPos): Boolean {
+            return if (factionChestMap.contains(pos)) {
                 factionChestMap.remove(pos)
+                false
             } else {
                 factionChestMap.add(pos)
+                true
             }
         }
 
@@ -49,7 +51,11 @@ class FactionStorage(private var isInUse: Boolean = false) : EnderChestInventory
             }
 
             val inventory = if (faction.id in factionInventories) factionInventories[faction.id]!!
-                else DataStore.loadObject("inventories/${faction.id}.dat", FactionStorage) { FactionStorage() }
+                else {
+                    val obj = DataStore.loadObject("inventories/${faction.id}.dat", FactionStorage) { FactionStorage() }
+                    factionInventories[faction.id] = obj
+                    obj
+                }
 
             if (inventory.isInUse) {
                 Message("Faction inventory is currently in use. Please try again later.")

--- a/src/main/kotlin/io/icker/factions/data/DataStore.kt
+++ b/src/main/kotlin/io/icker/factions/data/DataStore.kt
@@ -1,0 +1,62 @@
+package io.icker.factions.data
+
+import io.icker.factions.FactionsMod
+import net.fabricmc.loader.api.FabricLoader
+import net.minecraft.nbt.NbtCompound
+import net.minecraft.nbt.NbtElement
+import net.minecraft.nbt.NbtIo
+import java.io.IOException
+
+object DataStore {
+    private val rootPath = FabricLoader.getInstance().gameDir.resolve("world/factions")
+    private const val nbtRootKey = "root"
+
+    fun <T> loadObject(path: String, fromNbt: FromNbt<T>, default: () -> T): T {
+        val file = rootPath.resolve(path).toFile()
+
+        try {
+            return NbtIo.readCompressed(file)
+                .get(nbtRootKey)!!
+                .let { fromNbt.fromNbt(it) }
+        } catch (e: IOException) {
+            FactionsMod.LOGGER.error("Failed to read NBT data ({})", file, e)
+        }
+
+        return default()
+    }
+
+    fun <T> saveObject(path: String, value: T) where T: ToNbt<T> {
+        saveObject(path, value.toNbt())
+    }
+
+    fun <T> saveObject(path: String, value: T, toNbt: (T) -> NbtElement) {
+        saveObject(path, toNbt(value))
+    }
+
+    fun saveObject(path: String, nbt: NbtElement) {
+        val file = rootPath.resolve(path).toFile()
+
+        try {
+            val parent = file.parentFile
+            if (!parent.exists()) {
+                parent.mkdirs()
+            }
+
+            val data = NbtCompound()
+            data.put(nbtRootKey, nbt)
+            NbtIo.writeCompressed(data, file)
+        } catch (e: IOException) {
+            FactionsMod.LOGGER.error("Failed to write NBT data ({})", file, e)
+        }
+
+    }
+
+}
+
+fun interface ToNbt<in T> {
+    fun toNbt(): NbtElement
+}
+
+fun interface FromNbt<out T> {
+    fun fromNbt(nbt: NbtElement): T
+}

--- a/src/main/resources/factions.mixins.json
+++ b/src/main/resources/factions.mixins.json
@@ -9,7 +9,8 @@
         "MinecraftServerMixin",
         "ServerPlayerEntityMixin",
         "ServerPlayerInteractionManagerMixin",
-        "ServerPlayNetworkHandlerMixin"
+        "ServerPlayNetworkHandlerMixin",
+        "EnderChestMixin"
     ],
     "injectors": {
         "defaultRequire": 1


### PR DESCRIPTION
The current implementation works by marking the coordinates of ender chests are to be used for faction inventories. This is checked through an inject mixin on `EnderChestBlock.onUse`.

Individual chests are marked using the `/f toggleChestMode <X> <Y> <Z>` command.

Pending proper testing, hence the draft status of the PR.

This is an alternative to #4 .